### PR TITLE
chore: promote yolo to version 0.0.1

### DIFF
--- a/config-root/namespaces/jx-staging/yolo/yolo-ingress.yaml
+++ b/config-root/namespaces/jx-staging/yolo/yolo-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: yolo/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'yolo'
+  name: yolo
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: yolo
+              servicePort: 80
+      host: yolo-jx-staging.cloudport.amagi.tv

--- a/config-root/namespaces/jx-staging/yolo/yolo-svc.yaml
+++ b/config-root/namespaces/jx-staging/yolo/yolo-svc.yaml
@@ -1,0 +1,20 @@
+# Source: yolo/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: yolo
+  labels:
+    chart: "yolo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'yolo'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: yolo-yolo

--- a/config-root/namespaces/jx-staging/yolo/yolo-yolo-deploy.yaml
+++ b/config-root/namespaces/jx-staging/yolo/yolo-yolo-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: yolo/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: yolo-yolo
+  labels:
+    draft: draft-app
+    chart: "yolo-0.0.1"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'yolo'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: yolo-yolo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: yolo-yolo
+    spec:
+      serviceAccountName: yolo-yolo
+      containers:
+        - name: yolo
+          image: "ghcr.io/rohatgisanat-amagi/yolo:0.0.1"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.1
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/yolo/yolo-yolo-sa.yaml
+++ b/config-root/namespaces/jx-staging/yolo/yolo-yolo-sa.yaml
@@ -1,0 +1,10 @@
+# Source: yolo/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yolo-yolo
+  annotations:
+    meta.helm.sh/release-name: 'yolo'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,6 +89,12 @@
 	      <td><a href='http://p-dev-jx-staging.cloudport.amagi.tv'>view</a></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> yolo </a></td>
+	      <td>0.0.1</td>
+	      <td><a href='http://yolo-jx-staging.cloudport.amagi.tv'>view</a></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -193,3 +193,18 @@
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/p-dev
     version: 0.0.5
+  - apiVersion: v1
+    appVersion: 0.0.1
+    applicationUrl: http://yolo-jx-staging.cloudport.amagi.tv
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-06-13T00:01:02Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: yolo
+      url: http://yolo-jx-staging.cloudport.amagi.tv
+    lastDeployed: "2021-06-13T00:01:02Z"
+    name: yolo
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+    resourcePath: config-root/namespaces/jx-staging/yolo
+    version: 0.0.1

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -16,5 +16,7 @@ releases:
 - chart: dev/yolo
   version: 0.0.1
   name: yolo
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -13,5 +13,8 @@ releases:
   name: p-dev
   values:
   - jx-values.yaml
+- chart: dev/yolo
+  version: 0.0.1
+  name: yolo
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote yolo to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
