### PR TITLE
chore: promote p-dev to version 0.0.7

### DIFF
--- a/config-root/namespaces/jx-staging/p-dev/p-dev-p-dev-deploy.yaml
+++ b/config-root/namespaces/jx-staging/p-dev/p-dev-p-dev-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: p-dev-p-dev
   labels:
     draft: draft-app
-    chart: "p-dev-0.0.5"
+    chart: "p-dev-0.0.7"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'p-dev'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: p-dev-p-dev
       containers:
         - name: p-dev
-          image: "ghcr.io/rohatgisanat-amagi/p-dev:0.0.5"
+          image: "ghcr.io/rohatgisanat-amagi/p-dev:0.0.7"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.5
+              value: 0.0.7
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/p-dev/p-dev-svc.yaml
+++ b/config-root/namespaces/jx-staging/p-dev/p-dev-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: p-dev
   labels:
-    chart: "p-dev-0.0.5"
+    chart: "p-dev-0.0.7"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'p-dev'

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> p-dev </a></td>
-	      <td>0.0.5</td>
+	      <td>0.0.7</td>
 	      <td><a href='http://p-dev-jx-staging.cloudport.amagi.tv'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -179,20 +179,20 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.5
+    appVersion: 0.0.7
     applicationUrl: http://p-dev-jx-staging.cloudport.amagi.tv
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-06-12T23:30:55Z"
+    firstDeployed: "2021-06-13T00:09:17Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: p-dev
       url: http://p-dev-jx-staging.cloudport.amagi.tv
-    lastDeployed: "2021-06-12T23:30:55Z"
+    lastDeployed: "2021-06-13T00:09:17Z"
     name: p-dev
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/p-dev
-    version: 0.0.5
+    version: 0.0.7
   - apiVersion: v1
     appVersion: 0.0.1
     applicationUrl: http://yolo-jx-staging.cloudport.amagi.tv

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
 releases:
 - chart: dev/p-dev
-  version: 0.0.5
+  version: 0.0.7
   name: p-dev
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote p-dev to version 0.0.7

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
