### PR TITLE
chore: promote n-dev to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/n-dev/n-dev-ingress.yaml
+++ b/config-root/namespaces/jx-staging/n-dev/n-dev-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: n-dev/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'n-dev'
+  name: n-dev
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: n-dev
+              servicePort: 80
+      host: n-dev-jx-staging.cloudport.amagi.tv

--- a/config-root/namespaces/jx-staging/n-dev/n-dev-n-dev-deploy.yaml
+++ b/config-root/namespaces/jx-staging/n-dev/n-dev-n-dev-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: n-dev/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: n-dev-n-dev
+  labels:
+    draft: draft-app
+    chart: "n-dev-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'n-dev'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: n-dev-n-dev
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: n-dev-n-dev
+    spec:
+      serviceAccountName: n-dev-n-dev
+      containers:
+        - name: n-dev
+          image: "ghcr.io/rohatgisanat-amagi/n-dev:0.0.2"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.2
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/n-dev/n-dev-n-dev-sa.yaml
+++ b/config-root/namespaces/jx-staging/n-dev/n-dev-n-dev-sa.yaml
@@ -1,0 +1,10 @@
+# Source: n-dev/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: n-dev-n-dev
+  annotations:
+    meta.helm.sh/release-name: 'n-dev'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/n-dev/n-dev-svc.yaml
+++ b/config-root/namespaces/jx-staging/n-dev/n-dev-svc.yaml
@@ -1,0 +1,20 @@
+# Source: n-dev/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: n-dev
+  labels:
+    chart: "n-dev-0.0.2"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'n-dev'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: n-dev-n-dev

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,12 @@
 	      <td><a href='http://yolo-jx-staging.cloudport.amagi.tv'>view</a></td>
 	      <td></td>
 	    </tr>
+    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> n-dev </a></td>
+	      <td>0.0.2</td>
+	      <td><a href='http://n-dev-jx-staging.cloudport.amagi.tv'>view</a></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -208,3 +208,18 @@
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/yolo
     version: 0.0.1
+  - apiVersion: v1
+    appVersion: 0.0.2
+    applicationUrl: http://n-dev-jx-staging.cloudport.amagi.tv
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-06-13T00:16:08Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: n-dev
+      url: http://n-dev-jx-staging.cloudport.amagi.tv
+    lastDeployed: "2021-06-13T00:16:08Z"
+    name: n-dev
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
+    resourcePath: config-root/namespaces/jx-staging/n-dev
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -21,5 +21,7 @@ releases:
 - chart: dev/n-dev
   version: 0.0.2
   name: n-dev
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -18,5 +18,8 @@ releases:
   name: yolo
   values:
   - jx-values.yaml
+- chart: dev/n-dev
+  version: 0.0.2
+  name: n-dev
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote n-dev to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
