### PR TITLE
chore: promote n-dev to version 0.0.8

### DIFF
--- a/config-root/namespaces/jx-staging/n-dev/n-dev-n-dev-deploy.yaml
+++ b/config-root/namespaces/jx-staging/n-dev/n-dev-n-dev-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: n-dev-n-dev
   labels:
     draft: draft-app
-    chart: "n-dev-0.0.7"
+    chart: "n-dev-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'n-dev'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: n-dev-n-dev
       containers:
         - name: n-dev
-          image: "ghcr.io/rohatgisanat-amagi/n-dev:0.0.7"
+          image: "ghcr.io/rohatgisanat-amagi/n-dev:0.0.8"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.7
+              value: 0.0.8
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/n-dev/n-dev-svc.yaml
+++ b/config-root/namespaces/jx-staging/n-dev/n-dev-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: n-dev
   labels:
-    chart: "n-dev-0.0.7"
+    chart: "n-dev-0.0.8"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'n-dev'

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,7 +97,7 @@
 	    </tr>
     <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> n-dev </a></td>
-	      <td>0.0.7</td>
+	      <td>0.0.8</td>
 	      <td><a href='http://n-dev-jx-staging.cloudport.amagi.tv'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -209,17 +209,17 @@
     resourcePath: config-root/namespaces/jx-staging/yolo
     version: 0.0.1
   - apiVersion: v1
-    appVersion: 0.0.7
+    appVersion: 0.0.8
     applicationUrl: http://n-dev-jx-staging.cloudport.amagi.tv
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-06-13T16:32:04Z"
+    firstDeployed: "2021-06-14T07:02:57Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: n-dev
       url: http://n-dev-jx-staging.cloudport.amagi.tv
-    lastDeployed: "2021-06-13T16:32:04Z"
+    lastDeployed: "2021-06-14T07:02:57Z"
     name: n-dev
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts
     resourcePath: config-root/namespaces/jx-staging/n-dev
-    version: 0.0.7
+    version: 0.0.8

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -19,7 +19,7 @@ releases:
   values:
   - jx-values.yaml
 - chart: dev/n-dev
-  version: 0.0.7
+  version: 0.0.8
   name: n-dev
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote n-dev to version 0.0.8

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
